### PR TITLE
feat: Implement Batch Iota-Sigma UI and Panel Functionality

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -47,17 +47,18 @@
   <div class="panel left-panel">
     <div id="button-container">
       <!-- Auth Elements START -->
-      <div id="authSection" style="padding: 10px; border-bottom: 1px solid #444; margin-bottom: 10px;">
+      <div id="authSection">
         <div id="userStatus" style="color: white; margin-bottom: 10px; font-size: 0.9em;">Loading user status...</div>
+        <img id="userAvatar" src="#" alt="User Avatar" style="display:none; width: 24px; height: 24px; border-radius: 50%; margin-right: 8px;">
         <button id="signInButton" class="control-button auth-button" title="Sign In with Google">
           <svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 0 24 24" width="20px" fill="#FFFFFF"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 6.58l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/><path d="M1 1h22v22H1z" fill="none"/></svg>
-          Sign In
         </button>
         <button id="signOutButton" class="control-button auth-button" title="Sign Out" style="display: none;">
           <svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 0 24 24" width="20px" fill="#FFFFFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M17 7l-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4V5z"/></svg>
           Sign Out
         </button>
       </div>
+      <hr id="authSeparator">
       <!-- Auth Elements END -->
       <button id="loadAudioButton" class="control-button" title="Загрузить аудиофайл" aria-label="Upload File"><svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px"><path d="M440-440H200v-80h240v-240h80v240h240v80H520v240h-80v-240Z"/></svg></button>
       <input type="file" id="audioFileInput" accept="audio/*" style="display: none;">
@@ -100,6 +101,15 @@
       </div>
 
       <!-- История чата с Триа (Режим чата) -->
+      <!-- История чата с Триа (Режим чата) -->
+      <div id="myGesturesView" class="right-panel-view" style="display: none;">
+        <!-- Сюда будет добавляться список жестов -->
+        <p style="text-align: center; margin-top: 20px; color: grey;">Список жестов пуст</p>
+      </div>
+      <div id="myHologramsView" class="right-panel-view" style="display: none;">
+        <!-- Сюда будет добавляться список голограмм -->
+        <p style="text-align: center; margin-top: 20px; color: grey;">Список голограмм пуст</p>
+      </div>
       <div id="chatHistory" class="panel-section chat-mode" style="display: none;">
         <div id="chatMessages">
           <div id="loadingIndicator"></div>
@@ -112,16 +122,6 @@
       <p style="text-align: center; margin-top: 20px; color: grey;">История чата пуста</p>
         </div>
     
-    <div id="myGesturesView" class="right-panel-view" style="display: none;">
-      <!-- Сюда будет добавляться список жестов -->
-      <p style="text-align: center; margin-top: 20px; color: grey;">Список жестов пуст</p>
-    </div>
-    
-    <div id="myHologramsView" class="right-panel-view" style="display: none;">
-      <!-- Сюда будет добавляться список голограмм -->
-      <p style="text-align: center; margin-top: 20px; color: grey;">Список голограмм пуст</p>
-    </div>
-
     <!-- Общая разделительная линия (всегда видимая) -->
     <div class="panel-divider"></div>
 

--- a/frontend/js/core/auth.js
+++ b/frontend/js/core/auth.js
@@ -77,10 +77,22 @@ export async function userSignOut() {
  *   This callback is typically used to synchronize the user with the backend or perform other authenticated actions.
  */
 export function initAuthObserver(callbackAfterToken) {
+    const userAvatarElement = document.getElementById('userAvatar');
+
     onAuthStateChanged(auth, async (user) => {
         if (user) {
             // User is signed in. Update UI accordingly.
             if (userStatusDiv) userStatusDiv.textContent = `User: ${user.displayName || user.email}`;
+
+            if (userAvatarElement) {
+                if (user.photoURL) {
+                    userAvatarElement.src = user.photoURL;
+                    userAvatarElement.style.display = 'block';
+                } else {
+                    userAvatarElement.style.display = 'none';
+                }
+            }
+
             if (signInButton) signInButton.style.display = 'none'; // Hide sign-in button
             if (signOutButton) signOutButton.style.display = 'block'; // Show sign-out button
 
@@ -99,6 +111,11 @@ export function initAuthObserver(callbackAfterToken) {
         } else {
             // User is signed out. Update UI accordingly.
             if (userStatusDiv) userStatusDiv.textContent = 'No user signed in.';
+
+            if (userAvatarElement) {
+                userAvatarElement.style.display = 'none';
+            }
+
             if (signInButton) signInButton.style.display = 'block'; // Show sign-in button
             if (signOutButton) signOutButton.style.display = 'none'; // Hide sign-out button
             // Call the provided callback with null, indicating no user token.

--- a/frontend/js/ui/uiManager.js
+++ b/frontend/js/ui/uiManager.js
@@ -415,13 +415,13 @@ export function initializeMainUI() {
   // Gesture Record button also opens the 'My Gestures' panel.
   addButtonListener(uiElements.buttons.gestureRecordButton, () => {
       console.log("Gesture Record button clicked. Opening 'My Gestures' panel.");
-      panelManagerInstance.openContentPanel('myGesturesView'); // Opens the specific panel for gestures.
+      panelManagerInstance.openContentPanel('myGestures'); // Opens the specific panel for gestures.
   }, "Gesture Record button also attempts to open 'myGesturesView' panel.");
 
   // Hologram List button opens the 'My Holograms' panel.
   addButtonListener(uiElements.buttons.hologramListButton, () => {
       console.log("Hologram List button clicked. Opening 'My Holograms' panel.");
-      panelManagerInstance.openContentPanel('myHologramsView'); // Opens the specific panel for holograms.
+      panelManagerInstance.openContentPanel('myHolograms'); // Opens the specific panel for holograms.
   }, "Hologram List button opens 'myHologramsView' panel.");
 
   addButtonListener(uiElements.buttons.scanButton, null, "Scan button clicked - functionality pending.");

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -738,6 +738,45 @@ body {
   letter-spacing: 3px;
 }
 
+/* Authentication Section Styles */
+#authSection {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 10px;
+  margin-bottom: 10px; /* Or var(--spacing-md) if preferred and consistent */
+}
+
+#signInButton svg {
+  width: var(--icon-size);
+  height: var(--icon-size);
+}
+
+#userStatus {
+  font-size: var(--font-size-small);
+  color: var(--color-primary);
+  margin-bottom: var(--spacing-sm); /* e.g., 5px */
+  text-align: center;
+}
+
+#userAvatar {
+  /* Inline styles from HTML: display:none; width: 24px; height: 24px; border-radius: 50%; */
+  /* Overriding margin-right with margin-bottom due to flex-direction: column */
+  margin-right: 0;
+  margin-bottom: var(--spacing-sm); /* e.g., 5px */
+}
+
+#authSeparator {
+  border: none;
+  height: 1px;
+  background-color: var(--panel-border); /* #444 or rgba(255,255,255,0.34) */
+  margin-top: 10px;    /* This was the margin-bottom of the old authSection */
+  margin-bottom: 10px; /* Space after separator */
+  width: 90%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 /* Удаляем стиль заголовка истории чата */
 .history-title {
   display: none;


### PR DESCRIPTION
This commit addresses the redesign of the left authentication panel and enhances the right panel's content display capabilities.

Key changes include:

1.  **Left Panel Auth UI Redesign (JULES_PANEL_AUTH_UI_JULES):**
    *   I moved the Sign-In/Sign-Out buttons to the top of the left panel, within a dedicated `authSection`.
    *   The Google Sign-In button now displays only the icon.
    *   I added a user avatar placeholder, displayed upon successful sign-in if a photoURL is available.
    *   Your status text (name/email or "not signed in") is displayed appropriately.
    *   I added a styled horizontal separator below the authentication section.
    *   I updated `auth.js` to manage avatar visibility and `style.css` for new layouts.

2.  **Right Panel Content Display (JULES_RIGHT_PANEL_CONTENT_JULES):**
    *   I ensured `index.html` includes `divs` for `versionTimeline`, `myGesturesView`, `myHologramsView`, and `chatHistory` within the right panel's `.content-container`.
    *   I verified `panelManager.js` correctly switches visibility between these content views, with `versionTimeline` as the default.
    *   I corrected `uiManager.js` to use appropriate short keys when calling `panelManager.openContentPanel` for "Мои жесты", "Мои голограммы", and "Чат" buttons.

3.  **Chat Button UX (JULES_CHAT_BUTTON_UX_JULES):**
    *   I verified that `panelManager.js` correctly updates the chat input placeholder to "Ваше сообщение для Триа..." when the chat panel is active.
    *   I confirmed that "Применить" and "Отправить" buttons' visibility is correctly toggled based on whether the chat panel or another content view is active.
    *   The "Чат" button now correctly opens the chat panel. Switching to other views (e.g., "Мои жесты") correctly reverts the input area to the default prompt mode.