### PR TITLE
Fix: Correct UserModel import in models.__init__

### DIFF
--- a/backend/core/models/__init__.py
+++ b/backend/core/models/__init__.py
@@ -4,7 +4,7 @@
 from .base_models import CoreModel, IDModel, TimestampModel, BaseUUIDModel, current_time_utc
 
 # Import models from user_models.py
-from .user_models import UserModel
+from .user_models import UserPublic, UserInDB
 
 # Import models from tria_azr_models.py
 from .tria_azr_models import (


### PR DESCRIPTION
Corrects an ImportError in `backend/core/models/__init__.py` by removing the import of the outdated `UserModel`.

Replaced it with imports for `UserPublic` and `UserInDB` to reflect the current model structure after refactoring. This ensures that the necessary user models are correctly exported for use in other parts of the application.