### PR TITLE
refactor(core): Convert all relative model imports to absolute paths

### DIFF
--- a/backend/core/crud_operations.py
+++ b/backend/core/crud_operations.py
@@ -12,10 +12,10 @@ from datetime import datetime
 import logging
 
 # Import Pydantic models from their respective modules
-from ..models.user_models import UserInDB
-from ..models.multimodal_models import UserGestureModel
-from ..models.learning_log_models import TriaLearningLogModel
-from ..models.hologram_models import UserHologramResponseModel # Модель для ответа по голограммам
+from backend.core.models.user_models import UserInDB
+from backend.core.models.multimodal_models import UserGestureModel
+from backend.core.models.learning_log_models import TriaLearningLogModel
+from backend.core.models.hologram_models import UserHologramResponseModel
 
 # Configure logging for this module
 logger = logging.getLogger(__name__)

--- a/backend/core/tria_bots/ChunkProcessorBot.py
+++ b/backend/core/tria_bots/ChunkProcessorBot.py
@@ -4,8 +4,8 @@ from uuid import UUID, uuid4
 from datetime import datetime
 import logging # Import the logging module
 
-from ..models.multimodal_models import AudiovisualGesturalChunkModel
-from ..models.learning_log_models import TriaLearningLogModel
+from backend.core.models.multimodal_models import AudiovisualGesturalChunkModel
+from backend.core.models.learning_log_models import TriaLearningLogModel
 from ..crud_operations import create_audiovisual_gestural_chunk, create_tria_learning_log_entry
 
 # Configure logging for this module

--- a/backend/services/chunk_processor_service.py
+++ b/backend/services/chunk_processor_service.py
@@ -8,7 +8,6 @@
 # TODO: Call CRUD operations to store the chunk.
 # TODO: Potentially trigger Tria's learning process or MemoryBot update.
 
-# from ..models.interaction_chunk_model import InteractionChunkCreate
 # from ..db import crud_operations
 #
 # async def process_and_store_chunk(chunk_data: InteractionChunkCreate):

--- a/backend/services/tria_response_service.py
+++ b/backend/services/tria_response_service.py
@@ -8,7 +8,6 @@
 # TODO: Format Tria's output into a standardized response model.
 # TODO: Handle different types of Tria interactions (e.g., direct command, asynchronous update).
 
-# from ..models.tria_state_model import TriaCommand, TriaResponse
 # from ..tria_bots.coordination_service import TriaCoordinationService # Assuming CoordinationService class
 #
 # async def get_tria_response_for_command(command: TriaCommand) -> TriaResponse:


### PR DESCRIPTION
Corrected relative imports in `backend/core/crud_operations.py` and `backend/core/tria_bots/ChunkProcessorBot.py` to use absolute paths, pointing to `backend.core.models`. This resolves `ModuleNotFoundError` issues caused by the previous refactoring where `backend/models` directory was removed.