### PR TITLE
Fix: Correct import paths for JS modules

### DIFF
--- a/frontend/js/core/init.js
+++ b/frontend/js/core/init.js
@@ -142,7 +142,7 @@ import { MicrophoneManager } from '../audio/microphoneManager.js';
 import { AudioAnalyzer } from '../audio/audioAnalyzer.js';
 import { HologramRenderer } from '../3d/hologramRenderer.js';
 import { XRSessionManager } from '../xr/webxr_session_manager.js'; // Added for WebXR
-import PanelManager from '../../ui/panelManager.js';
+import PanelManager from '../ui/panelManager.js';
 
 // Функция для инициализации ядра приложения
 export async function initCore() {

--- a/frontend/js/legacy-bridge.js
+++ b/frontend/js/legacy-bridge.js
@@ -5,7 +5,7 @@ import { state, config } from './core/init.js';
 import { ui, toggleChatMode, togglePanels } from './core/ui.js';
 import { sendPrompt, insertTextIntoPrompt } from './ai/prompts.js';
 import { sendChatMessage, addMessageToChat } from './ai/chat.js';
-import { synthesizeSpeech, stopSpeech } from './audio/speech.js';
+// import { synthesizeSpeech, stopSpeech } from './audio/speech.js';
 import { getSelectedModel, setSelectedModel } from './ai/models.js';
 
 // Экспортируем объекты и функции для глобального доступа


### PR DESCRIPTION
I corrected an import path in `frontend/js/core/init.js` from `../../ui/panelManager.js` to `../ui/panelManager.js`.

I also commented out a broken import in `frontend/js/legacy-bridge.js` that pointed to a non-existent file (`./audio/speech.js`). This resolves a potential runtime error.