### PR TITLE
Fix: Force panel visibility and adjust hologram grid

### DIFF
--- a/frontend/js/3d/hologramRenderer.js
+++ b/frontend/js/3d/hologramRenderer.js
@@ -138,7 +138,7 @@ export class HologramRenderer {
     geometry.setAttribute('position', new THREE.Float32BufferAttribute(points, 3));
     const material = new THREE.LineBasicMaterial({
         color, 
-        opacity: 0.1, 
+        opacity: 0.001,
         transparent: true,
         // Disable depth testing/writing to ensure grid lines are always visible
         // and don't interfere with objects drawn at the same Z-depth.

--- a/frontend/js/ui/panelManager.js
+++ b/frontend/js/ui/panelManager.js
@@ -32,6 +32,7 @@ class PanelManager {
     /**
      * Initializes state for main left/right panels (visibility/скрытие)
      */
+    // Новая, упрощенная версия функции
     initializeMainPanelState() {
         this.leftPanelElement = document.querySelector('.panel.left-panel');
         this.rightPanelElement = document.querySelector('.panel.right-panel');
@@ -42,33 +43,20 @@ class PanelManager {
             return;
         }
 
-        // Default to visible
+        // Принудительно делаем панели видимыми при каждой загрузке
         this.leftPanelElement.classList.remove('hidden');
         this.rightPanelElement.classList.remove('hidden');
-        this.togglePanelsButtonElement.classList.remove('show-mode'); // Button shows "click to hide"
-        // this.arePanelsVisible = true;
-        console.log('Panels set to visible by default.');
+        this.togglePanelsButtonElement.classList.remove('show-mode');
 
-        // Check localStorage to override default visibility
-        try {
-            const panelsHiddenStored = localStorage.getItem('panelsHidden');
-            if (panelsHiddenStored === 'true') {
-                this.leftPanelElement.classList.add('hidden');
-                this.rightPanelElement.classList.add('hidden');
-                this.togglePanelsButtonElement.classList.add('show-mode'); // Button shows "click to show"
-                // this.arePanelsVisible = false;
-                console.log('Panels are hidden based on localStorage setting.');
-            } else {
-                console.log('Panels remain visible (localStorage setting is not "true" or not set).');
-            }
-        } catch (e) {
-            console.error('Error accessing localStorage for panel visibility:', e);
-            // Keep panels visible (the default) if localStorage access fails
-        }
+        // Очищаем старое сохраненное состояние, чтобы оно нам не мешало
+        localStorage.removeItem('panelsHidden');
+
+        console.log('Панели принудительно показаны при загрузке.');
         
         // Dispatch a resize event to ensure layouts adjust correctly after panel state is set.
+        // This might still be useful depending on how layout adjustments are handled elsewhere
         setTimeout(() => window.dispatchEvent(new Event('resize')), 50);
-        console.log(`Состояние основных панелей инициализировано.`);
+        // console.log(`Состояние основных панелей инициализировано.`); // Original log, can be kept or removed
     }
 
     /**


### PR DESCRIPTION
This commit addresses issues with UI elements not displaying as intended:

- Panels are now forcibly shown on load by modifying `panelManager.js`. The code that checked `localStorage` for `panelsHidden` has been removed, and `localStorage.removeItem('panelsHidden')` has been added to prevent this issue from recurring.
- Hologram grid line opacity in `hologramRenderer.js` has been set to `0.001` to make them nearly transparent.
- Interactivity of the hologram, including gesture handling in `gestures.js` and layout adjustments in `layoutManager.js`, has been verified to ensure they use the correct hologram pivot and respond to hand visibility.