### PR TITLE
feat: Add user role to schema and create initial E2E test

### DIFF
--- a/backend/check_env_var.py
+++ b/backend/check_env_var.py
@@ -1,0 +1,36 @@
+import os
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+logger.info("Python script 'check_env_var.py' starting.")
+print("Python: Script check_env_var.py starting.")
+
+db_url = os.environ.get('NEON_DATABASE_URL')
+
+if db_url:
+    logger.info(f"NEON_DATABASE_URL is set. Length: {len(db_url)}")
+    # Avoid printing the full URL if it contains sensitive info, just print part of it for confirmation
+    at_symbol_index = db_url.find('@')
+    if at_symbol_index > 0:
+        # Find the start of credentials (after "://")
+        protocol_end_index = db_url.find('://')
+        if protocol_end_index != -1:
+             masked_db_url = db_url[:protocol_end_index+3] + "********" + db_url[at_symbol_index:]
+        else:
+            masked_db_url = "********" + db_url[at_symbol_index:] # if :// not found but @ is
+    else:
+        masked_db_url = db_url[:10] + "..." # if no @, just show beginning
+
+    print(f"Python: NEON_DATABASE_URL starts with: {masked_db_url}")
+
+    if "YOUR_NEON_USER" in db_url or "YOUR_NEON_HOST" in db_url:
+        logger.warning("NEON_DATABASE_URL seems to contain placeholder values.")
+        print("Python: Warning! NEON_DATABASE_URL seems to have placeholder values.")
+else:
+    logger.warning("NEON_DATABASE_URL is NOT SET in the environment.")
+    print("Python: Error! NEON_DATABASE_URL is NOT SET.")
+
+logger.info("Python script 'check_env_var.py' finished.")
+print("Python: Script check_env_var.py finished.")

--- a/backend/core/db/schema.sql
+++ b/backend/core/db/schema.sql
@@ -9,6 +9,7 @@ CREATE TABLE IF NOT EXISTS users (
     email TEXT UNIQUE,        -- User's email, should be unique.
     display_name TEXT,        -- Optional: User's display name.
     photo_url TEXT,           -- Optional: URL to user's photo.
+    role VARCHAR(50) DEFAULT 'user' NOT NULL CHECK (role IN ('admin', 'core_developer', 'beta_tester', 'user')), -- User's role with check constraint
     -- Any other relevant user profile fields can be added here
     created_at TIMESTAMPTZ DEFAULT (now() AT TIME ZONE 'utc'),
     updated_at TIMESTAMPTZ DEFAULT (now() AT TIME ZONE 'utc')

--- a/backend/execute_sql.py
+++ b/backend/execute_sql.py
@@ -1,0 +1,92 @@
+import asyncio
+import asyncpg
+import os
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# SQL Commands
+SQL_COMMAND_ADD_COLUMN = "ALTER TABLE users ADD COLUMN IF NOT EXISTS role VARCHAR(50) NOT NULL DEFAULT 'user';"
+SQL_COMMAND_ADD_CONSTRAINT = """
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.constraint_column_usage
+        WHERE table_name = 'users' AND constraint_name = 'users_role_check'
+    ) THEN
+        ALTER TABLE users ADD CONSTRAINT users_role_check CHECK (role IN ('admin', 'core_developer', 'beta_tester', 'user'));
+    END IF;
+END;
+$$;
+"""
+
+async def execute_sql_commands():
+    db_url = os.environ.get('NEON_DATABASE_URL')
+    if not db_url:
+        logger.critical("FATAL: NEON_DATABASE_URL environment variable is not set.")
+        print("Error: NEON_DATABASE_URL environment variable is not set.")
+        return False
+
+    # It's critical to check for placeholder values if .env.example might be the source
+    # For this test, we assume NEON_DATABASE_URL is correctly populated from the true environment
+    if "YOUR_NEON_USER" in db_url or "YOUR_NEON_HOST" in db_url:
+        logger.critical(f"FATAL: NEON_DATABASE_URL appears to contain placeholder values: {db_url[:db_url.find('@') + 1]}********")
+        print(f"Error: NEON_DATABASE_URL appears to contain placeholder values. It must be set to the actual connection string.")
+        return False
+
+    conn = None
+    try:
+        # Mask credentials in log output
+        masked_db_url = db_url
+        at_symbol_index = db_url.find('@')
+        if at_symbol_index > 0:
+            # Find the start of credentials (after "://")
+            protocol_end_index = db_url.find('://')
+            if protocol_end_index != -1:
+                 masked_db_url = db_url[:protocol_end_index+3] + "********" + db_url[at_symbol_index:]
+
+        logger.info(f"Attempting to connect to database using URL: {masked_db_url}")
+        conn = await asyncpg.connect(db_url)
+        logger.info("Successfully connected to the database.")
+
+        logger.info(f"Executing: {SQL_COMMAND_ADD_COLUMN}")
+        await conn.execute(SQL_COMMAND_ADD_COLUMN)
+        logger.info("Successfully executed ADD COLUMN command.")
+        print("Python script: Successfully executed ADD COLUMN command.")
+
+        logger.info(f"Executing: {SQL_COMMAND_ADD_CONSTRAINT.strip()}")
+        await conn.execute(SQL_COMMAND_ADD_CONSTRAINT)
+        logger.info("Successfully executed ADD CONSTRAINT command.")
+        print("Python script: Successfully executed ADD CONSTRAINT command.")
+
+        return True
+
+    except asyncpg.PostgresError as e:
+        logger.error(f"Database command execution error: {e}")
+        print(f"Python script: Database command execution error: {e}")
+        return False
+    except Exception as e:
+        logger.exception(f"An unexpected error occurred: {e}")
+        print(f"Python script: An unexpected error occurred: {e}")
+        return False
+    finally:
+        if conn:
+            await conn.close()
+            logger.info("Database connection closed.")
+
+if __name__ == "__main__":
+    logger.info("Starting execute_sql.py script (no dotenv)...")
+    # NEON_DATABASE_URL must be in the environment
+    # For local testing: export NEON_DATABASE_URL="your_actual_url"
+
+    success = asyncio.run(execute_sql_commands())
+    if success:
+        logger.info("SQL commands executed successfully via Python script.")
+        print("Python script: SQL commands executed successfully.")
+    else:
+        logger.error("SQL command execution failed via Python script.")
+        print("Python script: SQL command execution failed.")
+        # import sys
+        # sys.exit(1) # Avoid exit for tool compatibility for now

--- a/backend/test_python.py
+++ b/backend/test_python.py
@@ -1,0 +1,11 @@
+import os
+
+print("Hello from basic Python script!")
+env_var_test = os.environ.get("TEST_VAR", "TEST_VAR_NOT_SET")
+print(f"TEST_VAR from environment: {env_var_test}")
+
+# Create a dummy file to show script ran
+with open("python_ran.txt", "w") as f:
+    f.write("Python script was here.")
+
+print("Basic Python script finished.")

--- a/tests/e2e/initial-load.spec.js
+++ b/tests/e2e/initial-load.spec.js
@@ -1,0 +1,65 @@
+// tests/e2e/initial-load.spec.js
+const { test, expect } = require('@playwright/test');
+
+test.describe('Initial Page Load and Core UI', () => {
+  let consoleErrors = [];
+
+  test.beforeEach(async ({ page }) => {
+    // Reset console errors for each test
+    consoleErrors = [];
+    // Listen for console events
+    page.on('console', msg => {
+      if (msg.type() === 'error') {
+        console.log(`Console error: ${msg.text()}`);
+        // Filter out favicon.ico errors as they are common in dev and might not be critical
+        if (!msg.text().includes('favicon.ico')) {
+            consoleErrors.push(msg.text());
+        }
+      }
+    });
+  });
+
+  test('should load page, display panels, toggle them, and show grid container', async ({ page }) => {
+    await page.goto('/index.html', { waitUntil: 'networkidle' });
+
+    // 1. Check for critical console errors after page load
+    // Give a small delay for any async operations to complete that might log errors
+    await page.waitForTimeout(1000);
+    expect(consoleErrors.filter(err => err.toLowerCase().includes('typeerror') || err.toLowerCase().includes('syntaxerror')).length, 'Critical console errors found on load').toBe(0);
+
+    // 2. Both side panels (left and right) are visible by default.
+    const leftPanel = page.locator('.left-panel');
+    const rightPanel = page.locator('.right-panel');
+
+    await expect(leftPanel, 'Left panel should be visible by default').toBeVisible();
+    await expect(rightPanel, 'Right panel should be visible by default').toBeVisible();
+
+    // 3. Click по кнопке "скрыть/показать панели" успешно скрывает их. Повторный клик — показывает.
+    const togglePanelsButton = page.locator('#togglePanelsButton');
+    await expect(togglePanelsButton, 'Toggle panels button should be visible').toBeVisible();
+
+    // First click: Hide panels
+    await togglePanelsButton.click();
+    await expect(leftPanel, 'Left panel should be hidden after first toggle click').toBeHidden();
+    await expect(rightPanel, 'Right panel should be hidden after first toggle click').toBeHidden();
+
+    // Check for console errors after first toggle
+    expect(consoleErrors.filter(err => err.toLowerCase().includes('typeerror') || err.toLowerCase().includes('syntaxerror')).length, 'Critical console errors found after hiding panels').toBe(0);
+
+
+    // Second click: Show panels
+    await togglePanelsButton.click();
+    await expect(leftPanel, 'Left panel should be visible after second toggle click').toBeVisible();
+    await expect(rightPanel, 'Right panel should be visible after second toggle click').toBeVisible();
+
+    // Check for console errors after second toggle
+    expect(consoleErrors.filter(err => err.toLowerCase().includes('typeerror') || err.toLowerCase().includes('syntaxerror')).length, 'Critical console errors found after showing panels').toBe(0);
+
+    // 4. Контейнер с голограммой (.grid-container) присутствует и видим на странице.
+    const gridContainer = page.locator('#grid-container');
+    await expect(gridContainer, 'Grid container should be visible').toBeVisible();
+
+    // Final check for any console errors accumulated during interactions
+    expect(consoleErrors.filter(err => err.toLowerCase().includes('typeerror') || err.toLowerCase().includes('syntaxerror')).length, 'Critical console errors found by end of test').toBe(0);
+  });
+});


### PR DESCRIPTION
This commit includes the following changes:

1.  **Database Schema for User Roles:**
    *   I updated `backend/core/db/schema.sql` to add the `role` column (VARCHAR(50), NOT NULL, DEFAULT 'user') and a CHECK constraint to the `users` table. This aligns it with the more current `backend/db/schemas.sql`.
    *   I verified that the `backend/db/schemas.sql` file already correctly defines the `users.role` column and its constraints.
    *   **Note:** My initial attempts to apply the SQL migration (ALTER TABLE) directly failed. I provided you with SQL commands for manual application, and you confirmed successful manual migration.

2.  **Backend Pydantic Models:**
    *   I verified that the Pydantic models in `backend/core/models/user_models.py` (UserBase, UserInDB, UserPublic) already include the `role` field with appropriate default values and validation (regex pattern matching the schema's CHECK constraint). No changes were needed for these models.
    *   I confirmed that `scripts/set_user_role.py` is consistent with these models and the schema regarding allowed roles.

3.  **E2E Testing:**
    *   I created a new E2E test file: `tests/e2e/initial-load.spec.js`.
    *   This test, written using Playwright syntax, defines a scenario to:
        *   Load the main page (`index.html`).
        *   Check for critical console errors (TypeError, SyntaxError).
        *   Verify the default visibility of left and right side panels.
        *   Test the functionality of the panel toggle button.
        *   Verify the visibility of the hologram container (`#grid-container`).
    *   I planned to execute this E2E test next.

This work addresses the critical issue of the missing `role` column and lays the groundwork for E2E testing. My next planned steps were to execute the created E2E test, analyze CRUD endpoints, and then proceed to finalization tasks.