### PR TITLE
Fix: Implement graceful WebGL error handling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -252,6 +252,23 @@
   <script type="module" src="./js/main.js"></script>
   <script type="module" src="./js/ui/panelManager.js"></script>
 
+  <!-- WebGL Error Overlay -->
+  <div id="webgl-error-overlay" style="display: none;">
+    <div id="webgl-error-message">
+      <h2>WebGL Initialization Error</h2>
+      <p>It seems your browser or device does not support WebGL, or it encountered an error during initialization.</p>
+      <p>Please try the following:</p>
+      <ul>
+        <li>Ensure WebGL is enabled in your browser settings.</li>
+        <li>Update your browser to the latest version.</li>
+        <li>Update your graphics card drivers.</li>
+        <li>Try a different browser.</li>
+      </ul>
+      <p>If the problem persists, your hardware might not be compatible.</p>
+      <p id="webgl-error-details" style="font-size: 0.8em; color: #ccc;"></p>
+    </div>
+  </div>
+
   <!-- Data Storage Consent Modal -->
   <div id="consent-modal" class="modal" style="display:none;">
     <div class="modal-content consent-modal-content">

--- a/frontend/js/3d/sceneSetup.js
+++ b/frontend/js/3d/sceneSetup.js
@@ -11,13 +11,31 @@ export function initializeScene(state) {
   state.scene = new THREE.Scene();
   state.scene.background = new THREE.Color(0x000000); // Black background
 
-  // Renderer: Initialize early to get gridContainer dimensions if needed by camera
-  // TODO: Implement WebGPU for performance boost.
-  state.renderer = new THREE.WebGLRenderer({
-    antialias: true, // Enable antialiasing for smoother edges
-    alpha: true      // Enable alpha for transparent background if needed by the page design
-  });
-  state.renderer.setPixelRatio(window.devicePixelRatio); // Adjust for device pixel ratio for sharper images
+  try {
+    // Renderer: Initialize early to get gridContainer dimensions if needed by camera
+    // TODO: Implement WebGPU for performance boost.
+    state.renderer = new THREE.WebGLRenderer({
+      antialias: true, // Enable antialiasing for smoother edges
+      alpha: true      // Enable alpha for transparent background if needed by the page design
+    });
+    state.renderer.setPixelRatio(window.devicePixelRatio); // Adjust for device pixel ratio for sharper images
+  } catch (error) {
+    console.error("WebGL Renderer Initialization Error:", error);
+    const errorOverlay = document.getElementById('webgl-error-overlay');
+    const errorDetails = document.getElementById('webgl-error-details');
+    if (errorOverlay) {
+      errorOverlay.style.display = 'flex';
+    }
+    if (errorDetails) {
+      errorDetails.textContent = `Error: ${error.message}`;
+    }
+    // Attempt to remove any partially created canvas
+    if (state.renderer && state.renderer.domElement && state.renderer.domElement.parentElement) {
+        state.renderer.domElement.parentElement.removeChild(state.renderer.domElement);
+    }
+    state.renderer = null; // Ensure renderer is not used
+    return false; // Indicate failure
+  }
 
   const gridContainer = document.getElementById('grid-container');
   if (!gridContainer) {
@@ -68,5 +86,6 @@ export function initializeScene(state) {
 
   // Removed Hologram Pivot creation from here. It is now created and managed by HologramRenderer.
   
-  console.log('sceneSetup.js: Scene initialized');
+  console.log('sceneSetup.js: Scene initialized successfully');
+  return true; // Indicate success
 }

--- a/frontend/js/ai/chat.js
+++ b/frontend/js/ai/chat.js
@@ -250,8 +250,8 @@ export async function sendChatMessage(messageText) {
       showLoadingIndicator(false);
       isWaitingForResponse = false;
     }
-  }
-// Removed extra closing brace here
+  // Extra brace removed
+}
 
 // Добавление сообщения в чат
 export function addMessageToChat(sender, messageText) {

--- a/frontend/js/core/init.js
+++ b/frontend/js/core/init.js
@@ -149,22 +149,22 @@ export async function initCore() {
   console.log('Инициализация ядра приложения...');
   
   // Инициализируем Three.js сцену
-  try {
-    // initializeScene теперь напрямую модифицирует объект state
-    initializeScene(state); // Pass state to initializeScene
-    
-    console.log('Three.js сцена успешно инициализирована');
-  } catch (error) {
-    console.error('Ошибка при инициализации Three.js сцены:', error);
-    // Fallback might not be useful if scene itself failed to init
-    // Consider if the app can run without a scene. If not, maybe rethrow or set a global error state.
+  const sceneInitialized = initializeScene(state); // Pass state and capture return value
+
+  if (!sceneInitialized) {
+    console.error('Scene setup failed (WebGL context error likely). Halting further rendering-dependent initialization.');
+    // The error overlay is displayed by initializeScene itself.
+    // No need to set a global error state here unless other non-rendering parts need to know.
+    return; // Stop further initialization
   }
 
-  // Proceed with other initializations only if scene is available
-  if (!state.scene) {
-    console.error('Scene not initialized, cannot proceed with Hologram and Audio setup.');
-    return; 
+  // At this point, scene and renderer should be initialized if sceneInitialized is true.
+  // state.renderer would be null if WebGLRenderer failed.
+  if (!state.renderer) {
+    console.error('Renderer not available after scene initialization, though initializeScene reported success. This should not happen. Halting.');
+    return;
   }
+  console.log('Three.js scene and renderer successfully initialized.');
 
   // Instantiate HologramRenderer
   // state.hologramPivot is created in initializeScene.

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1529,3 +1529,66 @@ body.dimmed-for-tour > *:not(.highlighted-element) {
   background-color: var(--button-action-hover, #0056b3);
 }
 /* --- End Consent Modal Styles --- */
+
+/* --- WebGL Error Overlay Styles --- */
+#webgl-error-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.9); /* Dark semi-transparent background */
+  color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  z-index: 2000; /* Ensure it's on top of everything */
+  padding: 20px;
+  box-sizing: border-box;
+  font-family: 'Inter', sans-serif;
+}
+
+#webgl-error-message {
+  background-color: var(--color-black-95, #1a1a1a);
+  padding: 30px;
+  border-radius: var(--border-radius-md, 8px);
+  border: 1px solid var(--panel-border, #333);
+  max-width: 600px;
+  box-shadow: 0 5px 20px rgba(0,0,0,0.5);
+}
+
+#webgl-error-message h2 {
+  color: var(--color-red-100, #ff0000);
+  margin-top: 0;
+  margin-bottom: 15px;
+  font-size: var(--font-size-large, 1.8em);
+}
+
+#webgl-error-message p {
+  margin-bottom: 10px;
+  line-height: 1.6;
+  font-size: var(--font-size-base, 1em);
+}
+
+#webgl-error-message ul {
+  text-align: left;
+  margin: 15px 0;
+  padding-left: 30px;
+}
+
+#webgl-error-message li {
+  margin-bottom: 8px;
+}
+
+#webgl-error-details {
+  margin-top: 20px;
+  font-size: 0.8em;
+  color: #aaaaaa; /* Lighter grey for less prominent details */
+  max-height: 100px;
+  overflow-y: auto;
+  border-top: 1px solid var(--panel-border, #333);
+  padding-top: 10px;
+}
+/* --- End WebGL Error Overlay Styles --- */


### PR DESCRIPTION
This commit introduces a graceful error handling mechanism for WebGL initialization failures.

Previously, if the browser or hardware did not support WebGL, the application would crash with multiple console errors.

Changes made:
- Added a full-screen overlay to `frontend/index.html` to display a user-friendly error message.
- Added CSS styles for the error overlay in `frontend/style.css`.
- Wrapped the WebGLRenderer initialization in `frontend/js/3d/sceneSetup.js` in a try...catch block. If an error occurs, the error overlay is displayed, and the function returns `false`.
- Modified `frontend/js/core/init.js` to check the return value of the scene initialization. If it's `false`, further initialization is stopped to prevent cascading errors.

This ensures that you are informed about the issue on systems with outdated graphics drivers and the application does not crash.