### PR TITLE
Fix: Correct importmap syntax and update start modal

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,7 +24,15 @@
   <meta name="twitter:card" content="summary_large_image">
 
   <!-- Import Map for Three.js modules -->
-  <script type="importmap">\n  {\n    "imports": {\n      "three": "https:\/\/unpkg.com\/three@0.165.0\/build\/three.module.js",\n      "three\/examples\/jsm\/": "https:\/\/unpkg.com\/three@0.165.0\/examples\/jsm\/",\n      "@tweenjs\/tween.js": "https:\/\/unpkg.com\/@tweenjs\/tween.js@23.1.1\/dist\/tween.esm.js"\n    }\n  }\n  <\/script>
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://unpkg.com/three@0.165.0/build/three.module.js",
+      "three/examples/jsm/": "https://unpkg.com/three@0.165.0/examples/jsm/",
+      "@tweenjs/tween.js": "https://unpkg.com/@tweenjs/tween.js@23.1.1/dist/tween.esm.js"
+    }
+  }
+</script>
 
   <!-- MediaPipe Libraries -->
   <script src="https://cdn.jsdelivr.net/npm/@mediapipe/camera_utils/camera_utils.js" crossorigin="anonymous"></script>
@@ -45,11 +53,19 @@
 </head>
 <body>
 
-  <div id="start-session-modal" class="modal" style="display: flex; justify-content: center; align-items: center; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.95); z-index: 20000;">
-    <div class="modal-content" style="background-color: #1c1c1e; padding: 30px; border-radius: 10px; text-align: center;">
-      <h2 style="color: #fff; margin-bottom: 20px;">Сеанс Готов</h2>
-      <p style="color: #ccc; margin-bottom: 30px;">Нажмите "START" для инициализации аудио и видео.</p>
-      <button id="start-session-button" style="background-color: #4CAF50; color: white; padding: 20px 40px; border: none; border-radius: 5px; font-size: 2em; cursor: pointer;">START</button>
+  <div id="start-session-modal" class="modal">
+    <div class="modal-content">
+      <div id="google-signin-container">
+        <!-- Кнопка входа Google будет здесь -->
+      </div>
+      <p class="consent-text">
+        Продолжая, вы даете согласие на обработку аудио- и видеоданных с ваших устройств. Эти данные используются исключительно в реальном времени для анализа и формирования голограммы и не сохраняются на наших серверах.
+      </p>
+      <div class="consent-checkbox-container">
+        <input type="checkbox" id="consent-checkbox">
+        <label for="consent-checkbox">Я понимаю и принимаю условия</label>
+      </div>
+      <button id="start-session-button" class="start-button-disabled" disabled>Начать</button>
     </div>
   </div>
 

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -356,6 +356,32 @@ document.addEventListener('DOMContentLoaded', async () => {
   console.log('[TTA Core] New managers initialized.');
   // --- END TTA CORE SYNTHESIS MANAGER INITIALIZATION ---
 
+  // New logic for consent checkbox and start button
+  const consentCheckbox = document.getElementById('consent-checkbox');
+  const startButton = document.getElementById('start-session-button');
+  const googleSignInBtn = document.getElementById('login-google-btn'); // Existing Google Sign-In button
+  const googleContainer = document.getElementById('google-signin-container'); // New container in the modal
+
+  if (googleSignInBtn && googleContainer) {
+    googleContainer.appendChild(googleSignInBtn);
+    // Ensure the button is visible if it was hidden by display:none or similar
+    googleSignInBtn.style.display = 'block'; // Or 'flex', 'inline-block' depending on desired layout
+     // Adjust button styling for the modal if necessary
+    googleSignInBtn.classList.add('google-signin-modal-style'); // Example class
+  }
+
+  if (consentCheckbox && startButton) {
+    consentCheckbox.addEventListener('change', () => {
+      if (consentCheckbox.checked) {
+        startButton.disabled = false;
+        startButton.classList.remove('start-button-disabled');
+      } else {
+        startButton.disabled = true;
+        startButton.classList.add('start-button-disabled');
+      }
+    });
+  }
+
   console.log('Инициализация завершена!');
 
   // 5. Start Animation Loop

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1847,3 +1847,46 @@ body.dimmed-for-tour > *:not(.highlighted-element) {
 }
 
 /* --- END TTA CORE SYNTHESIS STYLES --- */
+
+/* Стили для нового стартового окна */
+#start-session-modal .modal-content {
+    max-width: 400px;
+    background-color: #1a1a1b;
+    border: 1px solid #333;
+}
+#google-signin-container {
+    margin-bottom: 20px;
+}
+.consent-text {
+    font-size: 0.8em;
+    color: #aaa;
+    line-height: 1.5;
+    margin-bottom: 20px;
+}
+.consent-checkbox-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 20px;
+}
+.start-button-disabled {
+    background-color: #4a4a4a !important;
+    cursor: not-allowed !important;
+    box-shadow: none !important;
+}
+#start-session-button {
+    background: linear-gradient(145deg, #8A2BE2, #4B0082);
+    color: white;
+    border: none;
+    padding: 15px 30px;
+    font-size: 1.2em;
+    font-weight: bold;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 4px 15px rgba(138, 43, 226, 0.4);
+}
+#start-session-button:not(:disabled):hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(138, 43, 226, 0.6);
+}


### PR DESCRIPTION
This commit addresses two main issues:

1.  Corrects a syntax error in the importmap in `frontend/index.html`. The previous version had an invalid JSON structure (likely a trailing comma), which prevented modules like 'three' from being resolved. The importmap has been replaced with a syntactically correct version.

2.  Redesigns the start session modal window.
    - Replaced the HTML structure of `#start-session-modal` in `frontend/index.html` with a new layout.
    - Added corresponding CSS styles to `frontend/style.css` for the new modal, including a purple gradient button.
    - Updated `frontend/js/main.js` to:
        - Move the Google Sign-In button into the new modal's `#google-signin-container`.
        - Implement logic to enable the "Start" button only after you check the consent checkbox. The button's visual state (enabled/disabled) is also updated accordingly.

These changes aim to create a more stylish, functional, and error-free startup experience for you.