### PR TITLE
Fix runtime errors in GestureUIManager and main.js

### DIFF
--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -440,6 +440,7 @@ function onPointerUp() {
 }
 
 function onPointerMove(event) {
+  let newRotationX, newRotationY;
   if (!isDragging) return;
 
   const currentPointerX = (event.touches ? event.touches[0].clientX : event.clientX);
@@ -453,8 +454,8 @@ function onPointerMove(event) {
   const rotationAmountX = deltaY * sensitivity;
 
   if (state.hologramRendererInstance && state.hologramRendererInstance.getHologramPivot()) {
-    let newRotationY = startRotationY + rotationAmountY;
-    let newRotationX = startRotationX + rotationAmountX;
+    newRotationY = startRotationY + rotationAmountY; // Removed let
+    newRotationX = startRotationX + rotationAmountX; // Removed let
     newRotationX = Math.max(-rotationLimit, Math.min(rotationLimit, newRotationX));
     
     state.hologramRendererInstance.getHologramPivot().rotation.y = newRotationY;


### PR DESCRIPTION
This commit addresses two runtime errors:

1.  TypeError in GestureUIManager.js:
    - Moved `this.setHandsPresent(false)` from the constructor to the `initialize()` method.
    - Ensured event handlers passed to EventBus are correctly bound with `.bind(this)`.

2.  ReferenceError in main.js:
    - Declared `newRotationX` and `newRotationY` at the beginning of the `onPointerMove` function to prevent access before initialization.

These changes should resolve the issues blocking UI interactivity and hand gesture processing.