### PR TITLE
fix(eventbus): Use correct 'on'/'off' method names

### DIFF
--- a/frontend/js/managers/HologramManager.js
+++ b/frontend/js/managers/HologramManager.js
@@ -22,10 +22,10 @@ class HologramManager {
         this.GRID_HEIGHT = 260;
 
         console.log("HologramManager initialized");
-        this.subscribeToEvents();
+        this.initializeEventListeners();
     }
 
-    subscribeToEvents() {
+    initializeEventListeners() {
         if (!this.eventBus) {
             console.warn("HologramManager: EventBus not provided, cannot subscribe to hand or resize events.");
             return;
@@ -40,7 +40,7 @@ class HologramManager {
         // Let's add a direct subscription for simplicity here, can be refactored.
         window.addEventListener('resize', this.handleResize.bind(this));
 
-        console.log("HologramManager subscribed to relevant events.");
+        console.log("HologramManager initialized event listeners.");
     }
 
     handleHandPresence(present, results = null) {

--- a/frontend/js/ui/GestureUIManager.js
+++ b/frontend/js/ui/GestureUIManager.js
@@ -42,9 +42,9 @@ class GestureUIManager {
         this.boundHandleHandsDetected = this.handleHandsDetected.bind(this);
         this.boundHandleHandsLost = this.handleHandsLost.bind(this);
 
-        this.eventBus.subscribe('handsDetected', this.boundHandleHandsDetected);
-        this.eventBus.subscribe('handsLost', this.boundHandleHandsLost);
-        console.log("GestureUIManager subscribed to handsDetected and handsLost events via EventBus.subscribe.");
+        this.eventBus.on('handsDetected', this.boundHandleHandsDetected);
+        this.eventBus.on('handsLost', this.boundHandleHandsLost);
+        console.log("GestureUIManager subscribed to handsDetected and handsLost events via EventBus.on.");
 
         this.setHandsPresent(false); // Moved from constructor
     }
@@ -242,10 +242,10 @@ class GestureUIManager {
             // For now, this .off call is more of a placeholder.
             // Use stored bound handlers for unsubscription
             if (this.boundHandleHandsDetected) {
-                this.eventBus.unsubscribe('handsDetected', this.boundHandleHandsDetected);
+                this.eventBus.off('handsDetected', this.boundHandleHandsDetected);
             }
             if (this.boundHandleHandsLost) {
-                this.eventBus.unsubscribe('handsLost', this.boundHandleHandsLost);
+                this.eventBus.off('handsLost', this.boundHandleHandsLost);
             }
             console.log("GestureUIManager events unsubscribed.");
         }


### PR DESCRIPTION
I replaced 'subscribe' with 'on' and 'unsubscribe' with 'off' in GestureUIManager.js to align with the EventBus implementation.

I verified that HologramManager.js already uses the correct 'on'/'off' methods. I renamed subscribeToEvents to initializeEventListeners in HologramManager.js for clarity. I checked panelManager.js (as a potential UI manager) and it does not utilize the event bus.