### PR TITLE
Okay, I can help you with that. Here's the rewritten message:

### DIFF
--- a/frontend/js/ai/chat.js
+++ b/frontend/js/ai/chat.js
@@ -31,7 +31,7 @@ const START_TOUR_COMMANDS = ['start tour', 'начать тур', 'расска�
 const STOP_TOUR_COMMANDS = ['stop tour', 'закончить тур', 'выйти из тура', 'стоп'];
 
 // Инициализация чата
-export function setupChat() {
+export function setupChat(state) {
   console.log('Инициализация чата...');
   
   // Initialize chatHistoryContainer for addMessageToChat

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -338,7 +338,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   initializeSpeechInput(); // Sets up speech input, might be okay if not directly tied to 3D scene at this stage
 
   initializeTria(); // AI core, likely no immediate 3D dependency
-  setupChat(); // AI chat setup
+  setupChat(state); // AI chat setup
 
   // Generic handlers
   initializeResizeHandler(); // Handles window resize


### PR DESCRIPTION
fix(chat): Pass state to setupChat to resolve initialization error

The `setupChat` function in `frontend/js/ai/chat.js` was attempting to access UI elements before they were properly initialized. This was due to the `state` object, which contains these UI elements, not being passed to the function.

I've addressed the issue by:
1. Modifying the `setupChat` function in `frontend/js/ai/chat.js` to accept the `state` object as an argument.
2. Updating the call to `setupChat` in `frontend/js/main.js` to pass the `state` object.

These changes ensure that `setupChat` has access to the necessary UI elements at the time of its execution, resolving the `TypeError` and allowing the application to initialize correctly.