### PR TITLE
Fix: Remove unused import and function call for loadInitialFilesAndSe…

### DIFF
--- a/frontend/js/platforms/desktop/desktopInput.js
+++ b/frontend/js/platforms/desktop/desktopInput.js
@@ -1,6 +1,6 @@
 // frontend/js/platforms/desktop/desktopInput.js
 // import { state } from '../../core/init.js'; // Unused import
-import { applyPrompt, loadInitialFilesAndSetupEditor } from '../../core/domEventHandlers.js';
+import { applyPrompt } from '../../core/domEventHandlers.js';
 import { toggleFullscreen, initFullscreenListeners } from '../../utils/fullscreen.js';
 import { initializePrompts } from '../../ai/prompts.js';
 import { initializeVersionManager } from '../../ui/versionManager.js'; // Assuming initializeVersionManager is exported
@@ -22,13 +22,6 @@ export class DesktopInput {
         this.setupKeyboardListeners();
         this.setupMouseListeners(); // Will include modal submit buttons
         this.setupGeneralButtonListeners(); // Will include other general buttons
-
-        if (typeof loadInitialFilesAndSetupEditor === 'function') {
-            loadInitialFilesAndSetupEditor();
-            console.log("DesktopInput: Initialized file editor setup.");
-        } else {
-            console.error("DesktopInput: loadInitialFilesAndSetupEditor is not a function or not imported.");
-        }
 
         // console.log("DesktopInput: Initializing secondary managers..."); // Optional: for debugging
 


### PR DESCRIPTION
…tupEditor

This commit resolves a SyntaxError that occurred during application startup. The error was caused by an attempt to import and call the `loadInitialFilesAndSetupEditor` function in `frontend/js/platforms/desktop/desktopInput.js`.

This function was related to an old and unused file editor logic. The changes made include:
- Removing the import of `loadInitialFilesAndSetupEditor` from `../../core/domEventHandlers.js`.
- Ensuring that `applyPrompt` (which was part of the same import line) is still imported correctly.
- Removing the conditional block that called `loadInitialFilesAndSetupEditor()` within the `initialize()` method of `DesktopInput` class.

These changes should prevent the error and allow the application to initialize correctly.