### PR TITLE
Fix: Use default exports for platform-specific input managers

### DIFF
--- a/frontend/js/platforms/desktop/desktopInput.js
+++ b/frontend/js/platforms/desktop/desktopInput.js
@@ -12,7 +12,7 @@ import { initializeHammerGestures } from '../../core/gestures.js';
 import { initializeRightPanel } from '../../panels/rightPanelManager.js';
 import { initializeFileEditor } from '../../ui/fileEditor.js';
 
-export class DesktopInput {
+export default class DesktopInput {
     constructor(globalState) {
         this.state = globalState;
         console.log("DesktopInput instantiated.");

--- a/frontend/js/platforms/mobile/mobileInput.js
+++ b/frontend/js/platforms/mobile/mobileInput.js
@@ -13,7 +13,7 @@ import { initializeHammerGestures } from '../../core/gestures.js';
 import { initializeRightPanel } from '../../panels/rightPanelManager.js';
 import { initializeFileEditor } from '../../ui/fileEditor.js';
 
-export class MobileInput {
+export default class MobileInput {
     constructor(globalState) { // Or use 'state' as parameter name
         // console.log('MobileInput constructor');
         this.state = globalState; // Store the state

--- a/frontend/js/platforms/xr/xrInput.js
+++ b/frontend/js/platforms/xr/xrInput.js
@@ -1,7 +1,7 @@
 // frontend/js/platforms/xr/xrInput.js
 // Placeholder for XR-specific input handling
 
-export class XrInput {
+export default class XrInput {
     constructor(state) { // Accept global state
         this.state = state; // Store global state
         console.log("XrInput instantiated (placeholder).");


### PR DESCRIPTION
I changed the DesktopInput, MobileInput, and XrInput classes to use default exports. This resolves a SyntaxError that was caused by a mismatch between named exports and default imports in main.js.

The imports in main.js were already correctly using default import syntax.