### PR TITLE
fix(webgpu): Correct WebGPU module imports

### DIFF
--- a/docs/RU/Architecture/Infrastructure/WebGPUMigrationGuide.md
+++ b/docs/RU/Architecture/Infrastructure/WebGPUMigrationGuide.md
@@ -29,7 +29,7 @@
 import * as THREE from 'three';
 
 // Импорт WebGPURenderer из аддонов
-import { WebGPURenderer } from 'three/addons/renderers/webgpu/WebGPURenderer.js';
+import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
 
 // Импорт материалов для WebGPU нод
 import { MeshBasicNodeMaterial } from 'three/addons/nodes/Nodes.js';

--- a/frontend/js/3d/sceneSetup.js
+++ b/frontend/js/3d/sceneSetup.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
 
 /**
  * Initializes the Three.js scene, camera, renderer, and basic lighting.
@@ -40,7 +41,7 @@ export async function initializeScene(state) {
     // the import statement at the top of sceneSetup.js will need adjustment in a later step.
     // For now, proceed with THREE.WebGPURenderer
 
-    state.renderer = new THREE.WebGPURenderer({
+    state.renderer = new WebGPURenderer({
         antialias: true,
         powerPreference: 'high-performance' // Still relevant for WebGPU
     });


### PR DESCRIPTION
Resolved 'is not a constructor' error by correcting the import statements for WebGPURenderer. The application should now initialize the WebGPU renderer successfully. Updated WebGPUMigrationGuide.md to reflect the correct import syntax.