### PR TITLE
refactor(build): Implement importmap and stabilize renderer

### DIFF
--- a/frontend/js/3d/hologramRenderer.js
+++ b/frontend/js/3d/hologramRenderer.js
@@ -5,7 +5,7 @@ import { LineGeometry } from 'three/addons/lines/LineGeometry.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';
 import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
-import { MeshBasicNodeMaterial } from 'three/addons/nodes/Nodes.js';
+// import { MeshBasicNodeMaterial } from 'three/addons/nodes/Nodes.js'; // Removed
 import { semitones, GRID_WIDTH, GRID_HEIGHT, GRID_DEPTH, CELL_SIZE } from '../config/hologramConfig.js';
 
 /**
@@ -272,7 +272,7 @@ export class HologramRenderer {
     columnGroup.userData.initialX = initialX; // Store for later updates
 
     const geometry = new THREE.BoxGeometry(width, 2, 1); // width, height, depth
-    const material = new MeshBasicNodeMaterial({ color: semitone.color }); // Color from semitone data
+    const material = new THREE.MeshBasicMaterial({ color: semitone.color }); // Color from semitone data
     const columnMesh = new THREE.Mesh(geometry, material);
 
     columnMesh.position.set(width / 2, (semitoneIndex + 1) * 2, 0);

--- a/frontend/js/3d/sceneSetup.js
+++ b/frontend/js/3d/sceneSetup.js
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
 
 /**
  * Initializes the Three.js scene, camera, renderer, and basic lighting.
@@ -12,58 +11,30 @@ export async function initializeScene(state) {
   state.scene = new THREE.Scene();
   state.scene.background = new THREE.Color(0x000000); // Black background
 
-  // --- WebGPU Renderer Initialization ---
-  if (!navigator.gpu) {
-    console.error('CRITICAL: WebGPU not supported on this browser.');
-    const errorModal = document.getElementById('webgl-error-modal'); // We'll rename this modal later
-    if (errorModal) {
-        const errorMessageElement = errorModal.querySelector('.error-message-details');
-        if(errorMessageElement) errorMessageElement.textContent = 'WebGPU is not supported on this browser. Please use a modern browser like Chrome or Edge.';
-        errorModal.style.display = 'flex';
-    }
-    state.renderer = null;
-    state.scene = null; // Ensure scene and camera are also null on failure
-    state.camera = null;
-    return { scene: null, renderer: null, camera: null }; // Return null objects on failure
-  }
-
+  // --- WebGL Renderer Initialization ---
   try {
-    console.log('[WebGPU Init] Attempting to create WebGPURenderer...');
-    // Ensure THREE from 'three/webgpu' is imported if WebGPURenderer is not part of the main THREE namespace directly
-    // For now, assuming THREE.WebGPURenderer is available. If not, the import needs to be:
-    // import { WebGPURenderer } from 'three/webgpu'; (or similar, based on Three.js structure)
-    // And then used as: new WebGPURenderer(...)
-
-    // For the purpose of this subtask, assume 'three' is imported as:
-    // import * as THREE from 'three';
-    // and WebGPURenderer is available as THREE.WebGPURenderer
-    // If subtask fails due to THREE.WebGPURenderer not being a constructor,
-    // the import statement at the top of sceneSetup.js will need adjustment in a later step.
-    // For now, proceed with THREE.WebGPURenderer
-
-    state.renderer = new WebGPURenderer({
+    console.log('[WebGL Init] Attempting to create WebGLRenderer...');
+    state.renderer = new THREE.WebGLRenderer({
         antialias: true,
-        powerPreference: 'high-performance' // Still relevant for WebGPU
+        // powerPreference: 'high-performance' // Retained for potential relevance
     });
-
-    console.log('[WebGPU Init] WebGPURenderer instance created. Awaiting init()...');
-    await state.renderer.init(); // Asynchronous initialization for WebGPU
-    console.log('[WebGPU Init] renderer.init() completed.');
-
     state.renderer.setPixelRatio(window.devicePixelRatio);
-    // outputColorSpace is used in WebGPU instead of outputEncoding
-    // state.renderer.outputColorSpace = THREE.SRGBColorSpace; // Or other as needed, check Three.js docs
+    state.renderer.outputEncoding = THREE.sRGBEncoding; // Correct encoding for WebGL
 
-    console.log('[WebGPU Init] WebGPURenderer initialized successfully.');
+    console.log('[WebGL Init] WebGLRenderer initialized successfully.');
 
   } catch (error) {
-    console.error('CRITICAL: WebGPURenderer Initialization Failed.', error);
-    const errorModal = document.getElementById('webgl-error-modal'); // We'll rename this modal later
-    if (errorModal) {
-        const errorMessageElement = errorModal.querySelector('.error-message-details');
-        if(errorMessageElement) errorMessageElement.textContent = 'Failed to initialize WebGPU renderer: ' + error.message;
-        errorModal.style.display = 'flex';
+    console.error('CRITICAL: WebGLRenderer Initialization Failed.', error);
+    const errorOverlay = document.getElementById('webgl-error-overlay'); // Use the correct ID from index.html
+    const errorDetailsElement = document.getElementById('webgl-error-details');
+
+    if (errorOverlay) {
+        if (errorDetailsElement) {
+            errorDetailsElement.textContent = 'Failed to initialize WebGL renderer: ' + error.message;
+        }
+        errorOverlay.style.display = 'flex'; // Show the overlay
     }
+    // Clean up renderer if partially created and attached
     if (state.renderer && state.renderer.domElement && state.renderer.domElement.parentElement) {
         state.renderer.domElement.parentElement.removeChild(state.renderer.domElement);
     }

--- a/frontend/js/core/resizeHandler.js
+++ b/frontend/js/core/resizeHandler.js
@@ -1,4 +1,4 @@
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js'; // Добавляем импорт THREE для доступа к MathUtils
+import * as THREE from 'three'; // Добавляем импорт THREE для доступа к MathUtils
 // import { state } from './init.js'; // Removed import
 import { updateHologramLayout } from '../ui/layoutManager.js'; // Предполагаемое место, пока оставляем как есть
 import { debounce } from '../utils/helpers.js';

--- a/frontend/js/core/resizeHandler.test.js
+++ b/frontend/js/core/resizeHandler.test.js
@@ -37,7 +37,7 @@ import { state } from './init.js'; // This will be our mocked state
 import { updateHologramLayout } from '../ui/layoutManager.js'; // Mocked
 import { getPanelWidths } from './resizeHandler.js'; // Mocked
 // const THREE = require('three');
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+import * as THREE from 'three';
 
 describe('initializeResizeHandler', () => {
   let mockResizeHandler;

--- a/frontend/js/ui/layoutManager.js
+++ b/frontend/js/ui/layoutManager.js
@@ -1,5 +1,5 @@
 // frontend/js/ui/layoutManager.js
-import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js';
+import * as THREE from 'three';
 // Using window.TWEEN as it's included via script tag and updated in rendering.js
 // import * as TWEEN from '@tweenjs/tween.js';
 // import { state } from '../core/init.js'; // Removed import


### PR DESCRIPTION
- Implemented an importmap in index.html to manage all Three.js modules via CDN, establishing a single source of truth and resolving version conflicts.
- Refactored all JavaScript files to use "clean" modular imports (e.g., 'three', 'three/addons/...').
- Switched the renderer from WebGPU to the more stable WebGLRenderer for initial stabilization.
- Uninstalled the 'three' npm package as it's now managed by the browser via the importmap.
- Simplified vite.config.js by removing now-redundant resolve aliases.

This architectural change stabilizes the development environment and provides a solid foundation for future development. The return to WebGPU is planned as a separate, subsequent task.