### PR TITLE
fix(build): Explicitly define build entrypoint and output directory

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "frontend",
+    "public": "dist",
     "ignore": [
       "firebase.json",
       "**/.*",

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,5 +9,10 @@ export default defineConfig({
   },
   build: {
     target: 'esnext',
+    rollupOptions: {
+      input: {
+        main: '/index.html' // Явно указываем точку входа
+      }
+    }
   },
 });


### PR DESCRIPTION
- Modified vite.config.js to specify rollupOptions.input to ensure Vite correctly processes frontend/index.html as the main entry point.
- Updated firebase.json to change hosting.public from 'frontend' to 'dist', aligning with Vite's default output directory.