### PR TITLE
feat(core): Restore ES6 module imports

### DIFF
--- a/frontend/js/3d/hologramRenderer.js
+++ b/frontend/js/3d/hologramRenderer.js
@@ -1,3 +1,4 @@
+import * as THREE from 'three';
 import { Line2 } from 'three/addons/lines/Line2.js';
 import { LineMaterial } from 'three/addons/lines/LineMaterial.js';
 import { LineGeometry } from 'three/addons/lines/LineGeometry.js';

--- a/frontend/js/3d/rendering.js
+++ b/frontend/js/3d/rendering.js
@@ -1,4 +1,5 @@
 // frontend/js/rendering.js - Модуль для логики 3D-рендеринга
+import * as TWEEN from '@tweenjs/tween.js';
 
 // Импорты
 // import * as THREE from 'three'; // Not directly used in this file

--- a/frontend/js/3d/sceneSetup.js
+++ b/frontend/js/3d/sceneSetup.js
@@ -1,3 +1,5 @@
+import * as THREE from 'three';
+
 /**
  * Initializes the Three.js scene, camera, renderer, and basic lighting.
  * Assigns these components to the provided state object.

--- a/frontend/js/multimodal/handsTracking.js
+++ b/frontend/js/multimodal/handsTracking.js
@@ -1,4 +1,6 @@
 // handsTracking.js
+import * as THREE from 'three';
+import * as TWEEN from '@tweenjs/tween.js';
 
 // Using window.TWEEN as it's included via script tag and updated in rendering.js
 // Assuming THREE is global - No longer, THREE is imported

--- a/frontend/js/ui/GestureUIManager.js
+++ b/frontend/js/ui/GestureUIManager.js
@@ -4,7 +4,7 @@
 // Assuming an EventBus class/instance is available and imported
 // import EventBus from '../core/eventBus';
 // Using window.TWEEN as it's included via script tag and updated in rendering.js
-// import * as TWEEN from '@tweenjs/tween.js';
+import * as TWEEN from '@tweenjs/tween.js';
 
 class GestureUIManager {
     constructor(eventBus, state) { // appState changed to state
@@ -86,7 +86,7 @@ class GestureUIManager {
 
         if (this.currentAnimation) {
             this.currentAnimation.stop();
-            window.TWEEN.remove(this.currentAnimation); // Clean up old tween
+            TWEEN.remove(this.currentAnimation); // Clean up old tween
         }
 
         const initialHeightStyle = this.gestureAreaElement.style.height || getComputedStyle(this.gestureAreaElement).height;
@@ -114,9 +114,9 @@ class GestureUIManager {
         }
 
         const coords = { height: initialHeightPx };
-        this.currentAnimation = new window.TWEEN.Tween(coords)
+        this.currentAnimation = new TWEEN.Tween(coords)
             .to({ height: targetHeightPx }, 300) // 300ms animation duration
-            .easing(window.TWEEN.Easing.Quadratic.Out)
+            .easing(TWEEN.Easing.Quadratic.Out)
             .onUpdate(() => {
                 this.gestureAreaElement.style.height = `${coords.height}px`;
             })
@@ -253,7 +253,7 @@ class GestureUIManager {
         }
         if (this.currentAnimation) {
             this.currentAnimation.stop();
-            window.TWEEN.remove(this.currentAnimation);
+            TWEEN.remove(this.currentAnimation);
         }
         if (this.redLineElement) this.redLineElement.remove();
         this.clearFingerDots();


### PR DESCRIPTION
Added `import * as THREE from 'three';` to files that use THREE.js objects and methods but were missing the import.

Added `import * as TWEEN from '@tweenjs/tween.js';` to files that use TWEEN.js objects and methods but were missing the import.

Removed `window.` prefix from TWEEN usage in GestureUIManager.js now that it's imported directly.

This should resolve the `ReferenceError: THREE is not defined` and similar errors for TWEEN at runtime.