### PR TITLE
Fix audio data flow and Worklet initialization race condition

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,9 @@
+
+> holograms-media-backend@1.0.0 dev
+> vite
+
+
+  VITE v5.4.21  ready in 255 ms
+
+  ➜  Local:   http://localhost:8000/
+  ➜  Network: http://192.168.0.2:8000/

--- a/js/audio/audioProcessing.js
+++ b/js/audio/audioProcessing.js
@@ -19,10 +19,10 @@ let inputProxyNode = null;
 let proxyConnectedToWorklet = false;
 
 /**
- * Initializes or retrieves the global AudioContext.
+ * Initializes or retrieves the global AudioContext from AudioService.
  */
 export function getAudioContext() {
-    return audioService.getAudioContext() || new (window.AudioContext || window.webkitAudioContext)();
+    return audioService.getAudioContext();
 }
 
 /**
@@ -50,23 +50,21 @@ function connectProxyToWorklet() {
 }
 
 /**
- * Initializes the CQT AudioWorklet with WASM.
+ * Initializes the CQT AudioWorklet with WASM or JS fallback.
  */
 export async function initializeCwtWorklet(audioContext) {
-    if (cwtWorkletReady) {
+    if (cwtWorkletReady && cwtWorkletNode) {
         console.log('[AudioProcessing] CQT Worklet already initialized.');
-        connectProxyToWorklet(); // Ensure proxy is connected
+        connectProxyToWorklet();
         return true;
     }
 
-    // Ensure we are using the service's context if available
     if (!audioContext) {
         audioContext = audioService.getAudioContext();
     }
-    // If logic: if audioService is initialized, use it to ensure everything is sync
 
     console.log('[AudioProcessing] ========================================');
-    console.log('[AudioProcessing] INITIALIZING WASM CQT ENGINE');
+    console.log('[AudioProcessing] INITIALIZING CQT ENGINE');
     console.log('[AudioProcessing] ========================================');
 
     // Ensure proxy node exists
@@ -74,27 +72,9 @@ export async function initializeCwtWorklet(audioContext) {
 
     const caps = await deviceCapabilities.detect();
     const { sampleRate, chunkSize, numBins, channelCount } = caps.optimal;
-
     console.log(`[AudioProcessing] CQT Config: sampleRate=${sampleRate}, chunkSize=${chunkSize}, numBins=${numBins}`);
 
-    // 1. AudioWorklet is mainly managed by AudioService now, but we need to ensure it's loaded.
-    // AudioService.initialize() loads it. We assume it's done or we wait for it?
-    // Let's assume initializeCwtWorklet is called AFTER init.js calls audioService.initialize().
-
-    // 2. Get WASM Module from Service
-    let wasmModule = audioService.getWasmModule();
-    if (!wasmModule) {
-        console.warn('[AudioProcessing] WASM Module not found in AudioService. Attempting to force load (should not happen if init sequence is correct).');
-        // Could force init here, but safer to just warn
-    }
-
-    // 3. Create worklet node with flexible channel handling
-    // Note: We create a NEW node here specific for CQT logic as mapped in this file?
-    // Or should we use AudioService.createWorkletNode()?
-    // AudioProcessing.js has specific message handling logic (Gesture Modulation).
-    // AudioService has generic message handling.
-    // For Phase 2, let's keep logic here but use the resources.
-
+    // Create the AudioWorkletNode
     cwtWorkletNode = new AudioWorkletNode(audioContext, 'cwt-processor', {
         processorOptions: {
             sampleRate: sampleRate,
@@ -109,160 +89,145 @@ export async function initializeCwtWorklet(audioContext) {
         channelInterpretation: 'speakers'
     });
 
-    // 4. (DEFERRED) We will send the module and setup listeners inside the promise below
+    // ATTACH LISTENER BEFORE SENDING ANY MESSAGES
+    cwtWorkletNode.port.onmessage = (event) => {
+        handleWorkletMessage(event);
+    };
+
+    // Connect proxy to worklet
     connectProxyToWorklet();
 
-    // CRITICAL: Connect proxy to worklet NOW
-    connectProxyToWorklet();
+    const wasmModule = audioService.getWasmModule();
 
-    // 4. Wait for WASM_READY (only if WASM was loaded)
-    if (wasmModule) {
-        return new Promise((resolve) => {
-            const timeoutId = setTimeout(() => {
-                console.warn('[AudioProcessing] ⚠ WASM init timeout (5s). Fallback to current mode.');
+    return new Promise((resolve) => {
+        const timeoutId = setTimeout(() => {
+            if (!cwtWorkletReady) {
+                console.warn('[AudioProcessing] ⚠ WASM init timeout (5s). Switching to JS mode.');
                 cwtWorkletReady = true;
-                if (engineMode === 'INITIALIZING') engineMode = 'JS_GOERTZEL';
-                resolve(true);
-            }, 5000);
-
-            cwtWorkletNode.port.onmessage = (event) => {
-                const { type } = event.data;
-
-                if (type === 'WASM_READY') {
-                    clearTimeout(timeoutId);
-                    cwtWorkletReady = true;
-                    engineMode = 'CQT_WASM';
-                    console.log('[AudioProcessing] ✅ CQT WASM engine ready.');
-                    resolve(true);
-                } else if (type === 'WASM_ERROR') {
-                    clearTimeout(timeoutId);
-                    console.warn('[AudioProcessing] ⚠ WASM error, using JS fallback.');
-                    cwtWorkletReady = true;
-                    engineMode = 'JS_GOERTZEL';
-                    resolve(true);
-                } else if (type === 'AUDIO_DATA') {
-                    // DATA HANDLING (WASM or JS)
-                    const modulationData = state.multimodal?.gestureModulationData;
-                    const isSynthMode = state.audio?.isGestureSynthMode === true;
-
-                    const rawData = { levels: event.data.levels, pans: event.data.angles };
-                    const modulatedData = AudioGestureBridge.applyModulation(rawData, modulationData, isSynthMode);
-
-                    const levels = modulatedData.levels;
-                    const pans = modulatedData.pans;
-
-                    const fullPans = new Float32Array(256);
-                    if (pans && pans.length === 128) {
-                        fullPans.set(pans, 0);
-                        fullPans.set(pans, 128);
-                    } else if (pans && pans.length >= 256) {
-                        fullPans.set(pans.subarray(0, 256));
-                    }
-
-                    const payload = { levels: levels, pans: fullPans };
-
-                    // Debug logging (once per second)
-                    if (!this._dbgCount) this._dbgCount = 0;
-                    if (this._dbgCount++ % 60 === 0) {
-                        console.log(`[AudioProcessing] 📡 (${engineMode}) Emitting audioData. First bin:`, payload.levels?.[0]);
-                    }
-
-                    eventBus.emit('audioData', payload);
-                    state.audio.latestAudioData = { ...payload, timestamp: performance.now() };
-                }
-            };
-
-            // Trigger initialization in worklet
-            if (wasmModule) {
-                cwtWorkletNode.port.postMessage({ type: 'WASM_MODULE', module: wasmModule });
-            } else {
-                console.log('[AudioProcessing] ℹ️ Signal JS Mode to worklet.');
-                cwtWorkletNode.port.postMessage({ type: 'FORCE_JS_MODE' });
                 engineMode = 'JS_GOERTZEL';
-                // In JS mode, we still wait a bit or resolve immediately? 
-                // Better clear timeout and resolve if we know we are in JS mode.
+                cwtWorkletNode.port.postMessage({ type: 'FORCE_JS_MODE' });
+                resolve(true);
+            }
+        }, 5000);
+
+        // Internal helper to handle messages and resolve initialization
+        cwtWorkletNode.port.onmessage = (event) => {
+            const { type } = event.data;
+            if (type === 'WASM_READY') {
                 clearTimeout(timeoutId);
                 cwtWorkletReady = true;
+                engineMode = 'CQT_WASM';
+                console.log('[AudioProcessing] ✅ CQT WASM engine ready.');
+                resolve(true);
+            } else if (type === 'WASM_ERROR') {
+                clearTimeout(timeoutId);
+                console.warn('[AudioProcessing] ⚠ WASM error, using JS fallback.');
+                cwtWorkletReady = true;
+                engineMode = 'JS_GOERTZEL';
+                cwtWorkletNode.port.postMessage({ type: 'FORCE_JS_MODE' });
                 resolve(true);
             }
-        });
-    }
+            // Pass through to the main handler
+            handleWorkletMessage(event);
+        };
 
-    /**
-     * Sets up audio processing for a source node.
-     * SYNCHRONOUS GRAPH CONNECTION via proxy node.
-     * Async WASM loading happens in background.
-     */
-    export async function setupAudioProcessing(sourceNode, audioContext, connectToOutput = true) {
-        // Ensure AudioContext is running
-        if (audioContext.state === 'suspended') {
-            console.log('[AudioProcessing] ⚠ AudioContext suspended. Resuming...');
-            await audioContext.resume();
-            console.log(`[AudioProcessing] ✅ AudioContext state: ${audioContext.state}`);
-        }
-
-        // Get proxy node (creates if doesn't exist)
-        const proxy = getInputProxyNode(audioContext);
-
-        // SYNCHRONOUS CONNECTION: Source -> Proxy
-        // This happens IMMEDIATELY, no waiting for WASM
-        sourceNode.connect(proxy);
-        console.log(`[AudioProcessing] ✅ Source connected to proxy. Type: ${sourceNode.constructor.name}`);
-
-        // Start WASM initialization if not already running
-        if (!cwtWorkletReady && !cwtWorkletNode) {
-            // Fire and forget - don't block
-            initializeCwtWorklet(audioContext)
-                .then(() => {
-                    console.log('[AudioProcessing] ✅ CQT engine ready (background init).');
-                })
-                .catch((err) => {
-                    console.warn('[AudioProcessing] ⚠ CQT init failed:', err.message);
-                });
+        if (wasmModule) {
+            console.log('[AudioProcessing] Sending WASM module to worklet...');
+            cwtWorkletNode.port.postMessage({ type: 'WASM_MODULE', module: wasmModule });
         } else {
-            // Worklet already exists, ensure proxy is connected
-            connectProxyToWorklet();
+            console.log('[AudioProcessing] No WASM module found. Forcing JS mode.');
+            clearTimeout(timeoutId);
+            cwtWorkletReady = true;
+            engineMode = 'JS_GOERTZEL';
+            cwtWorkletNode.port.postMessage({ type: 'FORCE_JS_MODE' });
+            resolve(true);
+        }
+    });
+}
+
+/**
+ * Handles all messages from the AudioWorklet.
+ */
+function handleWorkletMessage(event) {
+    const { type } = event.data;
+
+    if (type === 'AUDIO_DATA') {
+        const modulationData = state.multimodal?.gestureModulationData;
+        const isSynthMode = state.audio?.isGestureSynthMode === true;
+
+        const rawData = { levels: event.data.levels, pans: event.data.angles };
+        const modulatedData = AudioGestureBridge.applyModulation(rawData, modulationData, isSynthMode);
+
+        const levels = modulatedData.levels;
+        const pans = modulatedData.pans;
+
+        // Ensure 256 bins for pans if necessary
+        const fullPans = new Float32Array(256);
+        if (pans && pans.length === 128) {
+            fullPans.set(pans, 0);
+            fullPans.set(pans, 128);
+        } else if (pans && pans.length >= 256) {
+            fullPans.set(pans.subarray(0, 256));
         }
 
-        // Connect source directly to output if requested (for hearing audio)
-        if (connectToOutput) {
-            sourceNode.connect(audioContext.destination);
+        const payload = { levels: levels, pans: fullPans };
+
+        // Diagnostic logging (once per 60 frames ~ 1s)
+        if (typeof handleWorkletMessage.dbgCount === 'undefined') handleWorkletMessage.dbgCount = 0;
+        if (handleWorkletMessage.dbgCount++ % 60 === 0) {
+            console.log(`[AudioProcessing] 📡 (${engineMode}) Emitting audioData. First bin:`, payload.levels?.[0]);
         }
 
-        console.log('[AudioProcessing] ✅ Audio source connected to processing pipeline.');
-        return proxy;
-    }
-
-    /**
-     * Disconnects a source from the CQT worklet.
-     */
-    export function disconnectFromCwt(sourceNode) {
-        if (inputProxyNode) {
-            try {
-                sourceNode.disconnect(inputProxyNode);
-            } catch (e) {
-                // Already disconnected
-            }
+        eventBus.emit('audioData', payload);
+        if (state.audio) {
+            state.audio.latestAudioData = { ...payload, timestamp: performance.now() };
         }
     }
+}
 
-    /**
-     * Returns whether CQT processing is active.
-     */
-    export function isCwtActive() {
-        return cwtWorkletReady && cwtWorkletNode !== null;
+/**
+ * Sets up audio processing for a source node.
+ */
+export async function setupAudioProcessing(sourceNode, audioContext, connectToOutput = true) {
+    if (!audioContext) {
+        audioContext = audioService.getAudioContext();
     }
 
-    /**
-     * Gets the current engine mode.
-     */
-    export function getEngineMode() {
-        return engineMode;
+    if (audioContext.state === 'suspended') {
+        console.log('[AudioProcessing] ⚠ Resuming context...');
+        await audioContext.resume();
     }
 
-    /**
-     * Gets the CQT worklet node for direct connection.
-     */
-    export function getCwtWorkletNode() {
-        return cwtWorkletNode;
+    const proxy = getInputProxyNode(audioContext);
+    sourceNode.connect(proxy);
+    console.log(`[AudioProcessing] ✅ Source connected to proxy. Type: ${sourceNode.constructor.name}`);
+
+    if (!cwtWorkletReady && !cwtWorkletNode) {
+        initializeCwtWorklet(audioContext).catch(err => console.error('[AudioProcessing] Init error:', err));
+    } else {
+        connectProxyToWorklet();
     }
+
+    if (connectToOutput) {
+        sourceNode.connect(audioContext.destination);
+    }
+
+    return proxy;
+}
+
+/**
+ * Disconnects a source from the CQT pipeline.
+ */
+export function disconnectFromCwt(sourceNode) {
+    if (inputProxyNode) {
+        try {
+            sourceNode.disconnect(inputProxyNode);
+        } catch (e) {
+            // Already disconnected
+        }
+    }
+}
+
+export function isCwtActive() { return cwtWorkletReady && cwtWorkletNode !== null; }
+export function getEngineMode() { return engineMode; }
+export function getCwtWorkletNode() { return cwtWorkletNode; }

--- a/js/audio/cwtAudioWorklet.js
+++ b/js/audio/cwtAudioWorklet.js
@@ -56,6 +56,7 @@ class CwtProcessor extends AudioWorkletProcessor {
         this.mode = 'INIT';
         this.targetFrequencies = new Float32Array(128);
         this.sampleRate = 48000;
+        this._dbgCount = 0;
 
         // JS Fallback State
         this.levels = new Float32Array(256).fill(-100);
@@ -121,6 +122,14 @@ class CwtProcessor extends AudioWorkletProcessor {
 
         const left = input[0];
         const right = input.length > 1 ? input[1] : left;
+
+        // --- DIAGNOSTIC LOGGING (Every 1s at 60fps) ---
+        if (this._dbgCount++ % 60 === 0) {
+            let sumSq = 0;
+            for (let i = 0; i < left.length; i++) sumSq += left[i] * left[i];
+            const rms = Math.sqrt(sumSq / left.length);
+            console.log(`[CwtProcessor] 🔊 Audio Flow Check: mode=${this.mode}, RMS=${rms.toFixed(6)}`);
+        }
 
         if (this.mode === 'WASM' && wasm) {
             try {

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -31,8 +31,14 @@ export default defineConfig({
     }
   },
   build: {
+    target: 'esnext',
     rollupOptions: {
       // Remove external: ['three'] to bundle it
+    }
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      target: 'esnext'
     }
   },
   assetsInclude: ['**/*.wasm']


### PR DESCRIPTION
This change fixes the issue where audio visualization columns had zero height due to an interrupted audio data flow. The root cause was a race condition in the AudioWorklet initialization where the 'WASM_READY' signal was being missed. 

I've refactored `audioProcessing.js` to use a Proxy Node pattern, ensuring audio sources can connect immediately. I also fixed the initialization sequence and added a robust fallback to JS processing if WASM fails or times out. Additionally, diagnostic logs were added to the worklet to monitor audio flow.

---
*PR created automatically by Jules for task [3318124549098780177](https://jules.google.com/task/3318124549098780177) started by @NeuroCoderZ*